### PR TITLE
Fixing a bug where clicking on the active tab doesn't pop to root

### DIFF
--- a/Sources/ESTabBar.swift
+++ b/Sources/ESTabBar.swift
@@ -371,7 +371,7 @@ internal extension ESTabBar /* Actions */ {
             } else if self.isMoreItem(newIndex) {
                 moreContentView?.reselect(animated: animated, completion: nil)
             }
-            if let tabBarController = tabBarController, let navVC = tabBarController.selectedViewController?.navigationController {
+            if let tabBarController = tabBarController, let navVC = tabBarController.selectedViewController as? UINavigationController {
                 if navVC.viewControllers.contains(tabBarController) {
                     if navVC.viewControllers.count > 1 && navVC.viewControllers.last != tabBarController {
                         navVC.popToViewController(tabBarController, animated: true);


### PR DESCRIPTION
To get the navigation controller of the current tab we need to take it directly from the `selectedViewController` and not from `selectedViewController?.navigationController`

Note:
`selectedViewController?.navigationController` works in the example project with the "More" tab however if we try to push a view controller to a normal view other than the "More" tab it will not gonna work.
`selectedViewController as? UINavigationController` is working in both cases