### PR TITLE
Include Localizable.strings file in podspec

### DIFF
--- a/ESTabBarController-swift.podspec
+++ b/ESTabBarController-swift.podspec
@@ -10,5 +10,6 @@ s.social_media_url  = 'https://github.com/eggswift'
 s.platform          = :ios, '8.0'
 s.source            = {:git => 'https://github.com/eggswift/ESTabBarController.git', :tag => s.version}
 s.source_files      = ['Sources/**/*.{swift}']
+s.resources         = ['Sources/**/*.{lproj}']
 s.requires_arc      = true
 end


### PR DESCRIPTION
Without this, accessibility labels aren't being set with properly formatted localized strings