### PR TITLE
iPhoneX safe area fix against current cocoa pod version (2.5)

### DIFF
--- a/Sources/ESTabBarItemContainer.swift
+++ b/Sources/ESTabBarItemContainer.swift
@@ -47,7 +47,6 @@ internal class ESTabBarItemContainer: UIControl {
         for subview in self.subviews {
             if let subview = subview as? ESTabBarItemContentView {
                 subview.frame = CGRect.init(x: subview.insets.left, y: subview.insets.top, width: bounds.size.width - subview.insets.left - subview.insets.right, height: bounds.size.height - subview.insets.top - subview.insets.bottom)
-                subview.updateLayout()
             }
         }
     }

--- a/Sources/ESTabBarItemContentView.swift
+++ b/Sources/ESTabBarItemContentView.swift
@@ -200,28 +200,37 @@ open class ESTabBarItemContentView: UIView {
         imageView.isHidden = (imageView.image == nil)
         titleLabel.isHidden = (titleLabel.text == nil)
         
+        var titleYOffset: CGFloat = 1
+        var imageYOffset: CGFloat = 6
+        var centerYOffset: CGFloat = 0
+        if #available(iOS 11.0, *), safeAreaInsets.bottom > 0  {
+            titleYOffset += safeAreaInsets.bottom
+            imageYOffset += safeAreaInsets.bottom / 2
+            centerYOffset += safeAreaInsets.bottom / 2
+        }
+        
         if !imageView.isHidden && !titleLabel.isHidden {
             titleLabel.sizeToFit()
             imageView.sizeToFit()
             titleLabel.frame = CGRect.init(x: (w - titleLabel.bounds.size.width) / 2.0,
-                                           y: h - titleLabel.bounds.size.height - 1.0,
+                                           y: h - titleLabel.bounds.size.height - titleYOffset,
                                            width: titleLabel.bounds.size.width,
                                            height: titleLabel.bounds.size.height)
             imageView.frame = CGRect.init(x: (w - imageView.bounds.size.width) / 2.0,
-                                          y: (h - imageView.bounds.size.height) / 2.0 - 6.0,
+                                          y: (h - imageView.bounds.size.height) / 2.0 - imageYOffset,
                                           width: imageView.bounds.size.width,
                                           height: imageView.bounds.size.height)
         } else if !imageView.isHidden {
             imageView.sizeToFit()
-            imageView.center = CGPoint.init(x: w / 2.0, y: h / 2.0)
+            imageView.center = CGPoint.init(x: w / 2.0, y: h / 2.0 - centerYOffset)
         } else if !titleLabel.isHidden {
             titleLabel.sizeToFit()
-            titleLabel.center = CGPoint.init(x: w / 2.0, y: h / 2.0)
+            titleLabel.center = CGPoint.init(x: w / 2.0, y: h / 2.0 - centerYOffset)
         }
         
         if let _ = badgeView.superview {
             let size = badgeView.sizeThatFits(self.frame.size)
-            badgeView.frame = CGRect.init(origin: CGPoint.init(x: w / 2.0 + badgeOffset.horizontal, y: h / 2.0 + badgeOffset.vertical), size: size)
+            badgeView.frame = CGRect.init(origin: CGPoint.init(x: w / 2.0 + badgeOffset.horizontal, y: h / 2.0 + badgeOffset.vertical - centerYOffset), size: size)
             badgeView.setNeedsLayout()
         }
     }
@@ -314,3 +323,4 @@ open class ESTabBarItemContentView: UIView {
     }
     
 }
+

--- a/Sources/ESTabBarItemContentView.swift
+++ b/Sources/ESTabBarItemContentView.swift
@@ -234,6 +234,11 @@ open class ESTabBarItemContentView: UIView {
             badgeView.setNeedsLayout()
         }
     }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        updateLayout()
+    }
 
     // MARK: - INTERNAL METHODS
     internal final func select(animated: Bool, completion: (() -> ())?) {


### PR DESCRIPTION
Use safeAreaInsets.bottom to adjust title and image offsets when necessary (iOS 11 only, iPhoneX only - safeAreaInsets.bottom is not zero)