### PR TITLE
Fix didSelect delegate not being called on reselection

### DIFF
--- a/Sources/ESTabBar.swift
+++ b/Sources/ESTabBar.swift
@@ -364,7 +364,6 @@ internal extension ESTabBar /* Actions */ {
             } else if self.isMoreItem(newIndex) {
                 moreContentView?.select(animated: animated, completion: nil)
             }
-            delegate?.tabBar?(self, didSelect: item)
         } else if currentIndex == newIndex {
             if let item = item as? ESTabBarItem {
                 item.contentView?.reselect(animated: animated, completion: nil)
@@ -395,6 +394,7 @@ internal extension ESTabBar /* Actions */ {
             }
         }
         
+        delegate?.tabBar?(self, didSelect: item)
         self.updateAccessibilityLabels()
     }
     


### PR DESCRIPTION
The native `UITabBarController` calls the delegate method `tabBarController(_:didSelect:)` even when reselecting a tab (see Discussion in the [Apple documentation](https://developer.apple.com/documentation/uikit/uitabbarcontrollerdelegate/1621173-tabbarcontroller#discussion))

This pull request fixes `ESTabBarController` to behave the same way. This is useful to implement special behavior when reselecting the same item (e.g. scrolling to top if the view controller has a scroll view, like Apple own apps)