### PR TITLE
Allow for explicit setting of the accessibility label, hint and identifier. Updates .selected trait

### DIFF
--- a/Sources/ESTabBar.swift
+++ b/Sources/ESTabBar.swift
@@ -418,7 +418,6 @@ internal extension ESTabBar /* Actions */ {
             if let explicitLabel = item.accessibilityLabel {
                 container.accessibilityLabel = explicitLabel
                 container.accessibilityHint = item.accessibilityHint ?? container.accessibilityHint
-                container.accessibilityTraits = item.accessibilityTraits
             } else {
                 var accessibilityTitle = ""
                 if let item = item as? ESTabBarItem {

--- a/Sources/ESTabBar.swift
+++ b/Sources/ESTabBar.swift
@@ -276,6 +276,7 @@ internal extension ESTabBar /* Actions */ {
             }
         }
         
+        self.updateAccessibilityLabels()
         self.setNeedsLayout()
     }
     
@@ -407,20 +408,31 @@ internal extension ESTabBar /* Actions */ {
         
         for (idx, item) in tabBarItems.enumerated() {
             let container = self.containers[idx]
-            var accessibilityTitle = ""
-            
-            if let item = item as? ESTabBarItem {
-                accessibilityTitle = item.accessibilityLabel ?? item.title ?? ""
-            }
-            if self.isMoreItem(idx) {
-                accessibilityTitle = NSLocalizedString("More_TabBarItem", bundle: Bundle(for:ESTabBarController.self), comment: "")
-            }
-            
-            let formatString = NSLocalizedString(item == selectedItem ? "TabBarItem_Selected_AccessibilityLabel" : "TabBarItem_AccessibilityLabel",
-                                                 bundle: Bundle(for: ESTabBarController.self),
-                                                 comment: "")
             container.accessibilityIdentifier = item.accessibilityIdentifier
-            container.accessibilityLabel = String(format: formatString, accessibilityTitle, idx + 1, tabBarItems.count)
+            container.accessibilityTraits = item.accessibilityTraits
+            
+            if item == selectedItem {
+                container.accessibilityTraits = container.accessibilityTraits.union(.selected)
+            }
+            
+            if let explicitLabel = item.accessibilityLabel {
+                container.accessibilityLabel = explicitLabel
+                container.accessibilityHint = item.accessibilityHint ?? container.accessibilityHint
+                container.accessibilityTraits = item.accessibilityTraits
+            } else {
+                var accessibilityTitle = ""
+                if let item = item as? ESTabBarItem {
+                    accessibilityTitle = item.accessibilityLabel ?? item.title ?? ""
+                }
+                if self.isMoreItem(idx) {
+                    accessibilityTitle = NSLocalizedString("More_TabBarItem", bundle: Bundle(for:ESTabBarController.self), comment: "")
+                }
+                
+                let formatString = NSLocalizedString(item == selectedItem ? "TabBarItem_Selected_AccessibilityLabel" : "TabBarItem_AccessibilityLabel",
+                                                     bundle: Bundle(for: ESTabBarController.self),
+                                                     comment: "")
+                container.accessibilityLabel = String(format: formatString, accessibilityTitle, idx + 1, tabBarItems.count)
+            }
             
         }
     }


### PR DESCRIPTION
Added the ability to set an explicit (and therefore localized) accessibiity label, hint and identifier.
Added the .selected accessibility trait when a tab item is selected.
Update accessibility labels on first start rather than after the first item is selected.

Falls back to existing functionality if these items aren't provided.

Usage:
let tabBarItem = ESTabBarItem(tabItem, title: nil, image: icon, selectedImage: icon)
navigationController.tabBarItem.accessibilityLabel = "Label"
navigationController.tabBarItem.accessibilityHint = "Hint"
navigationController.tabBarItem.accessibilityTraits = .button

Should resolve:
https://github.com/eggswift/ESTabBarController/issues/122

Should provide the same functionality as:
https://github.com/eggswift/ESTabBarController/pull/169