### PR TITLE
Support custom title font

### DIFF
--- a/Sources/ESTabBarItem.swift
+++ b/Sources/ESTabBarItem.swift
@@ -53,6 +53,12 @@ open class ESTabBarItem: UITabBarItem {
         {
         didSet { self.contentView?.title = title }
     }
+
+    open var titleFont: UIFont? {
+        didSet {
+            self.contentView?.titleFont = titleFont
+        }
+    }
     
     open override var image: UIImage? // default is nil
         {

--- a/Sources/ESTabBarItemContentView.swift
+++ b/Sources/ESTabBarItemContentView.swift
@@ -97,6 +97,12 @@ open class ESTabBarItemContentView: UIView {
             self.updateLayout()
         }
     }
+
+    open var titleFont: UIFont? {
+        didSet {
+            self.updateLayout()
+        }
+    }
     
     /// Icon imageView renderingMode, default is .alwaysTemplate like UITabBarItem
     open var renderingMode: UIImage.RenderingMode = .alwaysTemplate {
@@ -231,7 +237,7 @@ open class ESTabBarItemContentView: UIView {
             }
             
             if !imageView.isHidden && !titleLabel.isHidden {
-                titleLabel.font = UIFont.systemFont(ofSize: f)
+                titleLabel.font = titleFont ?? UIFont.systemFont(ofSize: f)
                 titleLabel.sizeToFit()
                 if #available(iOS 11.0, *), isWide {
                     titleLabel.frame = CGRect.init(x: (w - titleLabel.bounds.size.width) / 2.0 + (UIScreen.main.scale == 3.0 ? 14.25 : 12.25),
@@ -258,7 +264,7 @@ open class ESTabBarItemContentView: UIView {
                                               width: s,
                                               height: s)
             } else if !titleLabel.isHidden {
-                titleLabel.font = UIFont.systemFont(ofSize: f)
+                titleLabel.font = titleFont ?? UIFont.systemFont(ofSize: f)
                 titleLabel.sizeToFit()
                 titleLabel.frame = CGRect.init(x: (w - titleLabel.bounds.size.width) / 2.0,
                                                y: (h - titleLabel.bounds.size.height) / 2.0,


### PR DESCRIPTION
In this PR, I added the **support for custom title font**. We can customize title font in 2 ways:
- Set `titleFont` of `ESTabBarItem` when created
- Subclass `ESTabBarItemContentView` and override `titleFont`

