### PR TITLE
Support for Xcode 13 beta 3 (and 4)

### DIFF
--- a/Sources/ESTabBar.swift
+++ b/Sources/ESTabBar.swift
@@ -79,6 +79,7 @@ internal protocol ESTabBarDelegate: NSObjectProtocol {
 
 
 /// ESTabBar是高度自定义的UITabBar子类，通过添加UIControl的方式实现自定义tabBarItem的效果。目前支持tabBar的大部分属性的设置，例如delegate,items,selectedImge,itemPositioning,itemWidth,itemSpacing等，以后会更加细致的优化tabBar原有属性的设置效果。
+@available(iOSApplicationExtension, unavailable)
 open class ESTabBar: UITabBar {
 
     internal weak var customDelegate: ESTabBarDelegate?
@@ -160,6 +161,7 @@ open class ESTabBar: UITabBar {
     
 }
 
+@available(iOSApplicationExtension, unavailable)
 internal extension ESTabBar /* Layout */ {
     
     func updateLayout() {
@@ -244,6 +246,7 @@ internal extension ESTabBar /* Layout */ {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 internal extension ESTabBar /* Actions */ {
     
     func isMoreItem(_ index: Int) -> Bool {

--- a/Sources/ESTabBarController.swift
+++ b/Sources/ESTabBarController.swift
@@ -30,6 +30,7 @@ public typealias ESTabBarControllerShouldHijackHandler = ((_ tabBarController: U
 /// 自定义点击事件回调类型
 public typealias ESTabBarControllerDidHijackHandler = ((_ tabBarController: UITabBarController, _ viewController: UIViewController, _ index: Int) -> (Void))
 
+@available(iOSApplicationExtension, unavailable)
 open class ESTabBarController: UITabBarController, ESTabBarDelegate {
     
     /// 打印异常

--- a/Sources/ESTabBarItem.swift
+++ b/Sources/ESTabBarItem.swift
@@ -40,6 +40,7 @@ import UIKit
 ///     2. func badgeTextAttributes(for state: UIControlState) -> [String : Any]?
 ///
 @available(iOS 8.0, *)
+@available(iOSApplicationExtension, unavailable)
 open class ESTabBarItem: UITabBarItem {
     
     // MARK: UIView properties

--- a/Sources/ESTabBarItemContainer.swift
+++ b/Sources/ESTabBarItemContainer.swift
@@ -25,6 +25,7 @@
 
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 internal class ESTabBarItemContainer: UIControl {
     
     internal init(_ target: AnyObject?, tag: Int) {

--- a/Sources/ESTabBarItemContentView.swift
+++ b/Sources/ESTabBarItemContentView.swift
@@ -32,7 +32,7 @@ public enum ESTabBarItemContentMode : Int {
     case alwaysTemplate // Always set the image as a template image size
 }
 
-
+@available(iOSApplicationExtension, unavailable)
 open class ESTabBarItemContentView: UIView {
     
     // MARK: - PROPERTY SETTING
@@ -225,7 +225,7 @@ open class ESTabBarItemContentView: UIView {
         titleLabel.textColor = selected ? highlightTextColor : textColor
         backgroundColor = selected ? highlightBackdropColor : backdropColor
     }
-    
+
     open func updateLayout() {
         let w = self.bounds.size.width
         let h = self.bounds.size.height

--- a/Sources/ESTabBarItemMoreContentView.swift
+++ b/Sources/ESTabBarItemMoreContentView.swift
@@ -25,6 +25,7 @@
 
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 open class ESTabBarItemMoreContentView: ESTabBarItemContentView {
     
     public override init(frame: CGRect) {


### PR DESCRIPTION
## WHY

- Xcode 13 beta 3 introduces a breaking change related to API unavailable for iOS extensions: https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes

## WHAT

- https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/10
- Annotate with `@available(iOSApplicationExtension, unavailable)` only for modules that required annotation for beta 3 or 4 sdk building